### PR TITLE
allow Debian build test by github workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,61 @@
+name: Build and run tests
+on: [push, pull_request]
+env:
+  app_id: audiodecoder.hvl
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - name: "Debian package test"
+          os: ubuntu-18.04
+          CC: gcc
+          CXX: g++
+          DEBIAN_BUILD: true
+        #- os: ubuntu-18.04
+          #CC: gcc
+          #CXX: g++
+        #- os: ubuntu-18.04
+          #CC: clang
+          #CXX: clang++
+        #- os: macos-10.15
+    steps:
+    - name: Install needed ubuntu depends
+      env:
+        DEBIAN_BUILD: ${{ matrix.DEBIAN_BUILD }}
+      run: |
+        if [[ $DEBIAN_BUILD == true ]]; then sudo add-apt-repository -y ppa:team-xbmc/ppa; fi
+        if [[ $DEBIAN_BUILD == true ]]; then sudo apt-get update; fi
+        if [[ $DEBIAN_BUILD == true ]]; then sudo apt-get install fakeroot; fi
+    - name: Checkout Kodi repo
+      uses: actions/checkout@v2
+      with:
+        repository: xbmc/xbmc
+        ref: Matrix
+        path: xbmc
+    - name: Checkout audiodecoder.hvl repo
+      uses: actions/checkout@v2
+      with:
+        path: ${{ env.app_id }}
+    - name: Configure
+      env:
+        CC: ${{ matrix.CC }}
+        CXX: ${{ matrix.CXX }}
+        DEBIAN_BUILD: ${{ matrix.DEBIAN_BUILD }}
+      run: |
+        if [[ $DEBIAN_BUILD != true ]]; then cd ${app_id} && mkdir -p build && cd build; fi
+        if [[ $DEBIAN_BUILD != true ]]; then cmake -DADDONS_TO_BUILD=${app_id} -DADDON_SRC_PREFIX=${{ github.workspace }} -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}/xbmc/addons -DPACKAGE_ZIP=1 ${{ github.workspace }}/xbmc/cmake/addons; fi
+        if [[ $DEBIAN_BUILD == true ]]; then wget https://raw.githubusercontent.com/xbmc/xbmc/Matrix/xbmc/addons/kodi-dev-kit/tools/debian-addon-package-test.sh && chmod +x ./debian-addon-package-test.sh; fi
+        if [[ $DEBIAN_BUILD == true ]]; then sudo apt-get build-dep ${{ github.workspace }}/${app_id}; fi
+    - name: Build
+      env:
+        CC: ${{ matrix.CC }}
+        CXX: ${{ matrix.CXX }}
+        DEBIAN_BUILD: ${{ matrix.DEBIAN_BUILD }}
+      run: |
+        if [[ $DEBIAN_BUILD != true ]]; then cd ${app_id}/build; fi
+        if [[ $DEBIAN_BUILD != true ]]; then make; fi
+        if [[ $DEBIAN_BUILD == true ]]; then ./debian-addon-package-test.sh ${{ github.workspace }}/${app_id}; fi

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 This is a [Kodi](https://kodi.tv) audio decoder addon for HivelyTracker files.
 
 [![License: GPL-2.0-or-later](https://img.shields.io/badge/License-GPL%20v2+-blue.svg)](LICENSE.md)
+[![Build and run tests](https://github.com/xbmc/audiodecoder.hvl/actions/workflows/build.yml/badge.svg?branch=Matrix)](https://github.com/xbmc/audiodecoder.hvl/actions/workflows/build.yml)
 [![Build Status](https://travis-ci.org/xbmc/audiodecoder.hvl.svg?branch=Matrix)](https://travis-ci.org/xbmc/audiodecoder.hvl/branches)
 [![Build Status](https://dev.azure.com/teamkodi/binary-addons/_apis/build/status/xbmc.audiodecoder.hvl?branchName=Matrix)](https://dev.azure.com/teamkodi/binary-addons/_build/latest?definitionId=20&branchName=Matrix)
 [![Build Status](https://jenkins.kodi.tv/view/Addons/job/xbmc/job/audiodecoder.hvl/job/Matrix/badge/icon)](https://jenkins.kodi.tv/blue/organizations/jenkins/xbmc%2Faudiodecoder.hvl/branches/)
@@ -20,7 +21,7 @@ suggested by the README.
 
 1. `git clone --branch master https://github.com/xbmc/xbmc.git`
 2. `git clone https://github.com/xbmc/audiodecoder.hvl.git`
-3. `cd audiodecoder.wsr && mkdir build && cd build`
+3. `cd audiodecoder.hvl && mkdir build && cd build`
 4. `cmake -DADDONS_TO_BUILD=audiodecoder.hvl -DADDON_SRC_PREFIX=../.. -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=../../xbmc/kodi-build/addons -DPACKAGE_ZIP=1 ../../xbmc/cmake/addons`
 5. `make`
 


### PR DESCRIPTION
Separated from https://github.com/xbmc/audiodecoder.hvl/pull/2 to have available before other comes in.